### PR TITLE
Add individual blade components

### DIFF
--- a/src/FlashMessageServiceProvider.php
+++ b/src/FlashMessageServiceProvider.php
@@ -3,7 +3,12 @@
 namespace Bilfeldt\LaravelFlashMessage;
 
 use Bilfeldt\LaravelFlashMessage\View\Components\Alert;
+use Bilfeldt\LaravelFlashMessage\View\Components\AlertError;
+use Bilfeldt\LaravelFlashMessage\View\Components\AlertInfo;
+use Bilfeldt\LaravelFlashMessage\View\Components\AlertMessage;
 use Bilfeldt\LaravelFlashMessage\View\Components\AlertMessages;
+use Bilfeldt\LaravelFlashMessage\View\Components\AlertSuccess;
+use Bilfeldt\LaravelFlashMessage\View\Components\AlertWarning;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
@@ -27,8 +32,13 @@ class FlashMessageServiceProvider extends PackageServiceProvider
             ->hasViews() // required for the view component blade files to be registered
             ->hasViewComponents(
                 self::VIEW_COMPONENT_NAMESPACE,
+                AlertMessages::class,
                 Alert::class,
-                AlertMessages::class
+                AlertError::class,
+                AlertInfo::class,
+                AlertMessage::class,
+                AlertSuccess::class,
+                AlertWarning::class
             );
     }
 

--- a/src/View/Components/AbstractAlert.php
+++ b/src/View/Components/AbstractAlert.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bilfeldt\LaravelFlashMessage\View\Components;
+
+use Illuminate\View\Component;
+
+abstract class AbstractAlert extends Component
+{
+    public string $text;
+    public string $title;
+    public array $messages;
+    public array $links;
+
+    public function __construct(string $text, string $title = '', array $messages = [], array $links = [])
+    {
+        $this->text = $text;
+        $this->title = $title;
+        $this->messages = $messages;
+        $this->links = $links;
+    }
+}

--- a/src/View/Components/AlertError.php
+++ b/src/View/Components/AlertError.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bilfeldt\LaravelFlashMessage\View\Components;
+
+class AlertError extends AbstractAlert
+{
+    public function render()
+    {
+        return view('flash-message::components.alert-error');
+    }
+}

--- a/src/View/Components/AlertInfo.php
+++ b/src/View/Components/AlertInfo.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bilfeldt\LaravelFlashMessage\View\Components;
+
+class AlertInfo extends AbstractAlert
+{
+    public function render()
+    {
+        return view('flash-message::components.alert-info');
+    }
+}

--- a/src/View/Components/AlertMessage.php
+++ b/src/View/Components/AlertMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bilfeldt\LaravelFlashMessage\View\Components;
+
+class AlertMessage extends AbstractAlert
+{
+    public function render()
+    {
+        return view('flash-message::components.alert-message');
+    }
+}

--- a/src/View/Components/AlertSuccess.php
+++ b/src/View/Components/AlertSuccess.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bilfeldt\LaravelFlashMessage\View\Components;
+
+class AlertSuccess extends AbstractAlert
+{
+    public function render()
+    {
+        return view('flash-message::components.alert-success');
+    }
+}

--- a/src/View/Components/AlertWarning.php
+++ b/src/View/Components/AlertWarning.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Bilfeldt\LaravelFlashMessage\View\Components;
+
+class AlertWarning extends AbstractAlert
+{
+    public function render()
+    {
+        return view('flash-message::components.alert-warning');
+    }
+}


### PR DESCRIPTION
This PR adds dedicated blade components for use like so:

```php
<x-flash-alert-message
    title="Test title"
    text="test text"
/>

<x-flash-alert-info
    title="Test title"
    text="test text"
/>

<x-flash-alert-success
    title="Test title"
    text="test text"
/>

<x-flash-alert-warning
    title="Test title"
    text="test text"
/>

<x-flash-alert-error
    title="Test title"
    text="test text"
/>
```