### PR TITLE
Show error component only if validation errors exists and add formatt…

### DIFF
--- a/resources/views/components/errors.blade.php
+++ b/resources/views/components/errors.blade.php
@@ -1,9 +1,9 @@
-@if($hasMessages() || $errors)
+@if ($errors->getBag($bag)->any())
     <x-flash::alert
         :level="\Bilfeldt\LaravelFlashMessage\Message::LEVEL_ERROR"
         :title="$title"
         :text="$text"
-        :messages="$messages ? $messageBag()->all() : $errors->getBag($bag)->all()"
+        :messages="$errors->getBag($bag)->all($format)"
         :links="$links"
     ></x-flash-alert>
 @endif

--- a/src/View/Components/Errors.php
+++ b/src/View/Components/Errors.php
@@ -10,21 +10,11 @@ class Errors extends Component
     public function __construct(
         public string $title = '',
         public string $text = '',
-        public ?array $messages = null,
         public array $links = [],
-        public string $bag = 'default'
+        public string $bag = 'default',
+        public ?string $format = null,
     ) {
         //
-    }
-
-    public function hasMessages(): bool
-    {
-        return $this->messages !== null;
-    }
-
-    public function messageBag(): \Illuminate\Contracts\Support\MessageBag
-    {
-        return new MessageBag($this->messages);
     }
 
     public function render()

--- a/src/View/Components/Errors.php
+++ b/src/View/Components/Errors.php
@@ -2,7 +2,6 @@
 
 namespace Bilfeldt\LaravelFlashMessage\View\Components;
 
-use Illuminate\Support\MessageBag;
 use Illuminate\View\Component;
 
 class Errors extends Component

--- a/tests/ErrorsTest.php
+++ b/tests/ErrorsTest.php
@@ -42,4 +42,30 @@ class ErrorsTest extends TestCase
             ->assertSee('Example message 3');
     }
 
+    public function test_no_errors_renders_nothing()
+    {
+        View::share('errors', (new ViewErrorBag)->put('default', new MessageBag([])));
+
+        $view = $this->blade('<x-flash::errors />');
+
+        $view->assertDontSee('role="alert"', false);
+    }
+
+    public function test_error_formatting()
+    {
+        View::share('errors', (new ViewErrorBag)->put('default', new MessageBag([
+            'field_1' => 'Example message 1',
+            'field_2' => ['Example message 2', 'Example message 3'],
+        ])));
+
+        $view = $this->blade('<x-flash::errors :format="$format"/>', [
+            'format' => ':key: :message',
+        ]);
+
+        $view
+            ->assertSee('role="alert"', false)
+            ->assertSee('field_1: Example message 1')
+            ->assertSee('field_2: Example message 2')
+            ->assertSee('field_2: Example message 3');
+    }
 }


### PR DESCRIPTION
- [x] Fix issue that an empty alert blade was shown even if no validation errors were present
- [x] Remove `messages` from errors blade component
- [x] Add formatting option to the errors blade component  